### PR TITLE
Fix repping in threads of channels which reps shouldn't be allowed in

### DIFF
--- a/src/on_message.py
+++ b/src/on_message.py
@@ -164,8 +164,11 @@ async def on_message(message: discord.Message):
                               return
 
                         await message.delete()
-
-      isrepchannel = not message.channel.id in REP_DISABLE_CHANNELS
+      channel_id_rep = message.channel.id
+      if (type(message.channel) == discord.threads.Thread):
+          # Threads have different IDs than parent channel
+          channel_id_rep = message.channel.parent_id
+      isrepchannel = not channel_id_rep in REP_DISABLE_CHANNELS
       if gpdb.get_pref("rep_enabled", message.guild.id) and isrepchannel:
             await handle_rep(message)
       if message.channel.name == "counting":


### PR DESCRIPTION
Threads have their own unique IDs and do not have the same ID as the channel which is why repping is possible in threads in channels like off-topic, anon-confessions etc. This fix checks if the channel is a thread and gets the parent ID of the channel if it is a thread.