### PR TITLE
Get guild and channel from cache instead of fetching on every message

### DIFF
--- a/src/on_message.py
+++ b/src/on_message.py
@@ -85,10 +85,10 @@ async def handle_rep(message):
 @bot.event
 async def on_message(message: discord.Message):
     if message.author.bot: return
-    igcse = bot.get_guild(GUILD_ID) or await bot.fetch_guild(GUILD_ID)
-    logs = igcse.get_channel(BOTLOG_CHANNEL_ID) or await igcse.fetch_channel(BOTLOG_CHANNEL_ID)
 
     if SHOULD_LOG_ALL:
+        igcse = bot.get_guild(GUILD_ID) or await bot.fetch_guild(GUILD_ID)
+        logs = igcse.get_channel(BOTLOG_CHANNEL_ID) or await igcse.fetch_channel(BOTLOG_CHANNEL_ID)
         embed = discord.Embed(title="Message", description=message.content, color=0x5865f2)
         embed.set_author(name=message.author.name, url=message.jump_url, icon_url=message.author.avatar.url)
         embed.add_field(name="Created", value=f"<t:{int(message.created_at.timestamp())}>")

--- a/src/on_message.py
+++ b/src/on_message.py
@@ -85,8 +85,8 @@ async def handle_rep(message):
 @bot.event
 async def on_message(message: discord.Message):
     if message.author.bot: return
-    igcse = await bot.fetch_guild(GUILD_ID)
-    logs = await igcse.fetch_channel(BOTLOG_CHANNEL_ID)
+    igcse = bot.get_guild(GUILD_ID) or await bot.fetch_guild(GUILD_ID)
+    logs = igcse.get_channel(BOTLOG_CHANNEL_ID) or await igcse.fetch_channel(BOTLOG_CHANNEL_ID)
 
     if SHOULD_LOG_ALL:
         embed = discord.Embed(title="Message", description=message.content, color=0x5865f2)


### PR DESCRIPTION
For some odd reason, both guild and channel were being fetched on every single message sent in the server.

Now, the logs channel and guild are only fetched when required (aka when guild/channel is not present in cache and when SHOULD_LOG_ALL = True)