### PR TITLE
fix timestamps for punishments

### DIFF
--- a/src/mongodb.py
+++ b/src/mongodb.py
@@ -210,7 +210,7 @@ class PunishmentsDB:
         self.db = self.client.IGCSEBot
         self.punishment_history = self.db.punishment_history
     
-    def add_punishment(self, case_id: int | str, action_against: int, action_by: int, reason: str, action: str, when: datetime = datetime.utcnow(), duration: str = None):
+    def add_punishment(self, case_id: int | str, action_against: int, action_by: int, reason: str, action: str, when = None, duration: str = None):
         self.punishment_history.insert_one({
             "case_id": str(case_id),
             "action_against": str(action_against),
@@ -218,7 +218,7 @@ class PunishmentsDB:
             "reason": reason,
             "action": action,
             "duration": duration,
-            "when": when
+            "when": when or datetime.utcnow()
         })
     
     def get_punishments_by_user(self, user_id: int):


### PR DESCRIPTION
for some dumb reason, python calls the function datetime.utcnow() when the code is being parsed instead of when the function is called when passed as default for an arg.
