### PR TITLE
Fixed /snipe type:Edited not registering first edit

### DIFF
--- a/src/events/on_message_edit.py
+++ b/src/events/on_message_edit.py
@@ -16,5 +16,5 @@ async def on_message_edit(before: discord.Message, after: discord.Message):
         content_after=after.content,
         author_name=before.author.name,
         author_icon_url=before.author.display_avatar.url,
-        timestamp=str(before.edited_at.timestamp()),
+        timestamp=str(after.edited_at.timestamp()),
     ).save().expire(90)


### PR DESCRIPTION
- The bot was unable to resolve the timestamp at which the message was edited and would return the wrong timestamp when edited a second time
- Changed `before.edited_at.timestamp()` to `after.edited_at.timestamp()`