### PR TITLE
fix: /practice works in threads

### DIFF
--- a/src/commands/gostudy.py
+++ b/src/commands/gostudy.py
@@ -89,7 +89,7 @@ async def gostudy(
 
             await Logging.send(embed=embed)
             await channel.send(
-                f"{user.name} has been put on forced mute until <t:{unmute_time}:f>, which is <t:{unmute_time}:R>."
+                f"{user.name} has been sent to study until <t:{unmute_time}:f>, which is <t:{unmute_time}:R>."
             )
 
             embed = discord.Embed(

--- a/src/commands/practice/practice.py
+++ b/src/commands/practice/practice.py
@@ -196,7 +196,13 @@ async def new_session(interaction: discord.Interaction):
     else:
         thread_type = discord.ChannelType.public_thread
 
-    thread = await interaction.channel.create_thread(
+    channel = (
+        interaction.channel.parent_channel
+        if isinstance(interaction.channel, discord.Thread)
+        else interaction.channel
+    )
+
+    thread = await channel.create_thread(
         name=f"{interaction.user}'s practice session", type=thread_type
     )
 


### PR DESCRIPTION
- Added a check to see if the command was run in a thread, if it was the parent channel is where the thread is made
- Fixed unable to create a thread in a thread error